### PR TITLE
forwarded port should match links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The graphQL API contains *queries*, *mutations* and *subscriptions*. For a Confe
 Pull and run the image.
 
 ```
-docker run -d --name grapql-demo -p 8088:8080 npalm/graphql-java-demo
+docker run -d --name grapql-demo -p 8080:8080 npalm/graphql-java-demo
 ```
 
 The following endpoints are now available:


### PR DESCRIPTION
Documentation does not match configuration. Either container port forwarding should be 8080 or documantion should provide links to localhostr:8088.

I choose to modify the docker command, because I needed to change less.